### PR TITLE
Bugfix: Campaign values not registering in GA

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -91,7 +91,7 @@ module.exports = class Analytics {
     if (Object.keys(attribution).length > 0) {
       const validationResult = attributionSchema.validate(attribution)
       if (validationResult.error) {
-        throw new Error('Attribution should contain campaign and one of source or id')
+        console.warn('Attribution should contain campaign and one of source or id')
       }
     }
 

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -4,6 +4,16 @@ const BATCH_SIZE = process.env.HAPI_GAPI_BATCH_SIZE || 20
 const MAX_QUEUE_TIME = 14400000
 const debug = require('debug')('hapi-gapi')
 const ipAnonymise = require('ip-anonymize')
+const Joi = require('@hapi/joi')
+
+const attributionSchema = Joi.object({
+  campaign: Joi.string().required(),
+  source: Joi.string(),
+  medium: Joi.string(),
+  term: Joi.string(),
+  content: Joi.string(),
+  id: Joi.string()
+}).or('source', 'id')
 
 module.exports = class Analytics {
   constructor ({
@@ -78,6 +88,12 @@ module.exports = class Analytics {
     }
     const sessionId = await this._sessionIdProducer(request)
     const attribution = (await this._attributionProducer(request)) || {}
+    if (Object.keys(attribution).length > 0) {
+      const validationResult = attributionSchema.validate(attribution)
+      if (validationResult.error) {
+        throw new Error('Attribution should contain campaign and one of source or id')
+      }
+    }
 
     for (const property of this._propertySettings) {
       if (!property.hitTypes.includes(type)) {

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -7,12 +7,14 @@ const ipAnonymise = require('ip-anonymize')
 const Joi = require('@hapi/joi')
 
 const attributionSchema = Joi.object({
-  campaign: Joi.string().required(),
-  source: Joi.string(),
+  campaign: Joi.string()
+    .trim()
+    .required(),
+  source: Joi.string().trim(),
   medium: Joi.string(),
   term: Joi.string(),
   content: Joi.string(),
-  id: Joi.string()
+  id: Joi.string().trim()
 }).or('source', 'id')
 
 module.exports = class Analytics {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra/hapi-gapi",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "hapi plugin to enable server-side google analytics platform integration",
   "main": "lib/index.js",
   "directories": {

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -150,10 +150,16 @@ describe('Analytics', () => {
   })
 
   ;[
-    { desc: 'cn and cs specified', test: { campaign: 'cn1', source: 'cs' }, res: true },
-    { desc: 'cn and ci specified', test: { campaign: 'cn2', id: 'cid2' }, res: true },
-    { desc: 'cn omitted', test: { source: 'cs', id: 'cid3' }, res: false },
-    { desc: 'cs and ci omitted', test: { campaign: 'cn1' }, res: false }
+    { desc: 'campaign and source specified', test: { campaign: 'cn1', source: 'cs' }, res: true },
+    { desc: 'campaign and id specified', test: { campaign: 'cn2', id: 'cid2' }, res: true },
+    { desc: 'campaign omitted', test: { source: 'cs', id: 'cid3' }, res: false },
+    { desc: 'source and id omitted', test: { campaign: 'cn1' }, res: false },
+    { desc: 'campaign specified but zero length', test: { campaign: '', source: 'cs' }, res: false },
+    { desc: 'campaign specified but just spaces', test: { campaign: '   ', source: 'cs' }, res: false },
+    { desc: 'source specified but zero length', test: { campaign: 'cn1', source: '' }, res: false },
+    { desc: 'source specified but just spaces', test: { campaign: 'cn1', source: '   ' }, res: false },
+    { desc: 'id specified but zero length', test: { campaign: 'cn1', id: '' }, res: false },
+    { desc: 'id specified but just spaces', test: { campaign: 'cn1', id: '   ' }, res: false }
   ].forEach(({ desc, test, res }) => {
     it(`validates that return value of attribution producer has a cn value and one of cm or cs (${desc})`, async () => {
       const attributionProducer = () => test

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -147,14 +147,14 @@ describe('Analytics', () => {
     })
     analytics.ga(DEFAULT_REQUEST_OBJ).pageView()
     expect(attributionProducer.callCount).to.equal(0)
-  });
+  })
 
-  ([
+  ;[
     { desc: 'cn and cs specified', test: { campaign: 'cn1', source: 'cs' }, res: true },
     { desc: 'cn and ci specified', test: { campaign: 'cn2', id: 'cid2' }, res: true },
     { desc: 'cn omitted', test: { source: 'cs', id: 'cid3' }, res: false },
     { desc: 'cs and ci omitted', test: { campaign: 'cn1' }, res: false }
-  ]).forEach(({ desc, test, res }) => {
+  ].forEach(({ desc, test, res }) => {
     it(`validates that return value of attribution producer has a cn value and one of cm or cs (${desc})`, async () => {
       const attributionProducer = () => test
       const analytics = new Analytics({
@@ -162,12 +162,13 @@ describe('Analytics', () => {
         sessionIdProducer: r => {},
         attributionProducer
       })
+      sinon.spy(console, 'warn')
       if (res) {
-        await expect(analytics.ga(DEFAULT_REQUEST_OBJ).pageView()).not.reject()
+        await analytics.ga(DEFAULT_REQUEST_OBJ).pageView()
+        expect(console.warn.calledWith('Attribution should contain campaign and one of source or id')).to.equal(false)
       } else {
-        await expect(analytics.ga(DEFAULT_REQUEST_OBJ).pageView()).reject(
-          'Attribution should contain campaign and one of source or id'
-        )
+        await analytics.ga(DEFAULT_REQUEST_OBJ).pageView()
+        expect(console.warn.calledWith('Attribution should contain campaign and one of source or id')).to.equal(true)
       }
     })
   })

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -147,6 +147,29 @@ describe('Analytics', () => {
     })
     analytics.ga(DEFAULT_REQUEST_OBJ).pageView()
     expect(attributionProducer.callCount).to.equal(0)
+  });
+
+  ([
+    { desc: 'cn and cs specified', test: { campaign: 'cn1', source: 'cs' }, res: true },
+    { desc: 'cn and ci specified', test: { campaign: 'cn2', id: 'cid2' }, res: true },
+    { desc: 'cn omitted', test: { source: 'cs', id: 'cid3' }, res: false },
+    { desc: 'cs and ci omitted', test: { campaign: 'cn1' }, res: false }
+  ]).forEach(({ desc, test, res }) => {
+    it(`validates that return value of attribution producer has a cn value and one of cm or cs (${desc})`, async () => {
+      const attributionProducer = () => test
+      const analytics = new Analytics({
+        propertySettings: TEST_PROPERTY_SETTINGS,
+        sessionIdProducer: r => {},
+        attributionProducer
+      })
+      if (res) {
+        await expect(analytics.ga(DEFAULT_REQUEST_OBJ).pageView()).not.reject()
+      } else {
+        await expect(analytics.ga(DEFAULT_REQUEST_OBJ).pageView()).reject(
+          'Attribution should contain campaign and one of source or id'
+        )
+      }
+    })
   })
 
   it('handles page views with attribution', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-1297

In the first implementation of this plugin, we're just sending campaign name (`cn`) and campaign medium (`cm`) values and these are not showing in Google Analytics. Via trial and error, I've discovered that campaign name and one of campaign source (`cs`) or campaign id (`ci`) are required for campaign values to register. Therefore, we'll have error feedback in hapi-gapi if the required values aren't specified.