### PR TITLE
Support requests with proxy

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,4 +1,4 @@
-const Wreck = require('@hapi/wreck')
+const wreck = require('@hapi/wreck')
 const HttpsProxyAgent = require('https-proxy-agent')
 const debug = require('debug')('hapi-gapi')
 const ipAnonymise = require('ip-anonymize')
@@ -9,9 +9,7 @@ const BATCH_SIZE = process.env.HAPI_GAPI_BATCH_SIZE || 20
 const MAX_QUEUE_TIME = 14400000
 const HTTPS_PROXY = process.env.HTTPS_PROXY || process.env.https_proxy
 
-const wreck = Wreck.defaults({
-  agent: HTTPS_PROXY ? new HttpsProxyAgent(HTTPS_PROXY) : undefined
-})
+const agent = HTTPS_PROXY ? new HttpsProxyAgent(HTTPS_PROXY) : undefined
 
 const attributionSchema = Joi.object({
   campaign: Joi.string()
@@ -156,7 +154,7 @@ module.exports = class Analytics {
         .join('\n')
       debug('Processing buffered payload: \n%s', payload)
       // Don't await the request - the api always returns a 200 (even on error) and we don't want to block the server request being handled.
-      wreck.request('post', 'https://www.google-analytics.com/batch', { payload: payload, timeout: 15000 }).then(() => {
+      wreck.request('post', 'https://www.google-analytics.com/batch', { agent, payload: payload, timeout: 15000 }).then(() => {
         debug('Completed request to google analytics measurement protocol API')
       })
     }

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,5 +1,5 @@
 const Wreck = require('@hapi/wreck')
-const HttpsProxyAgent = require('https-proxy-agent');
+const HttpsProxyAgent = require('https-proxy-agent')
 const debug = require('debug')('hapi-gapi')
 const ipAnonymise = require('ip-anonymize')
 const Joi = require('@hapi/joi')
@@ -11,7 +11,7 @@ const HTTPS_PROXY = process.env.HTTPS_PROXY || process.env.https_proxy
 
 const wreck = Wreck.defaults({
   agent: HTTPS_PROXY ? new HttpsProxyAgent(HTTPS_PROXY) : undefined
-});
+})
 
 const attributionSchema = Joi.object({
   campaign: Joi.string()

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,10 +1,17 @@
-const fetch = require('node-fetch')
-const BATCH_INTERVAL = process.env.HAPI_GAPI_BATCH_INTERVAL || 15000
-const BATCH_SIZE = process.env.HAPI_GAPI_BATCH_SIZE || 20
-const MAX_QUEUE_TIME = 14400000
+const Wreck = require('@hapi/wreck')
+const HttpsProxyAgent = require('https-proxy-agent');
 const debug = require('debug')('hapi-gapi')
 const ipAnonymise = require('ip-anonymize')
 const Joi = require('@hapi/joi')
+
+const BATCH_INTERVAL = process.env.HAPI_GAPI_BATCH_INTERVAL || 15000
+const BATCH_SIZE = process.env.HAPI_GAPI_BATCH_SIZE || 20
+const MAX_QUEUE_TIME = 14400000
+const HTTPS_PROXY = process.env.HTTPS_PROXY || process.env.https_proxy
+
+const wreck = Wreck.defaults({
+  agent: HTTPS_PROXY ? new HttpsProxyAgent(HTTPS_PROXY) : undefined
+});
 
 const attributionSchema = Joi.object({
   campaign: Joi.string()
@@ -149,7 +156,7 @@ module.exports = class Analytics {
         .join('\n')
       debug('Processing buffered payload: \n%s', payload)
       // Don't await the request - the api always returns a 200 (even on error) and we don't want to block the server request being handled.
-      fetch('https://www.google-analytics.com/batch', { method: 'POST', body: payload, timeout: 15000 }).then(() => {
+      wreck.request('post', 'https://www.google-analytics.com/batch', { payload: payload, timeout: 15000 }).then(() => {
         debug('Completed request to google analytics measurement protocol API')
       })
     }

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -7,9 +7,6 @@ const Joi = require('@hapi/joi')
 const BATCH_INTERVAL = process.env.HAPI_GAPI_BATCH_INTERVAL || 15000
 const BATCH_SIZE = process.env.HAPI_GAPI_BATCH_SIZE || 20
 const MAX_QUEUE_TIME = 14400000
-const HTTPS_PROXY = process.env.HTTPS_PROXY || process.env.https_proxy
-
-const agent = HTTPS_PROXY ? new HttpsProxyAgent(HTTPS_PROXY) : undefined
 
 const attributionSchema = Joi.object({
   campaign: Joi.string()
@@ -41,6 +38,8 @@ module.exports = class Analytics {
     if (this._batchSize > 1) {
       this._heartbeat = setInterval(this.send.bind(this), this._batchInterval)
     }
+    const HTTPS_PROXY = process.env.HTTPS_PROXY || process.env.https_proxy
+    this._agent = HTTPS_PROXY ? new HttpsProxyAgent(HTTPS_PROXY) : undefined
   }
 
   ga (request) {
@@ -154,7 +153,7 @@ module.exports = class Analytics {
         .join('\n')
       debug('Processing buffered payload: \n%s', payload)
       // Don't await the request - the api always returns a 200 (even on error) and we don't want to block the server request being handled.
-      wreck.request('post', 'https://www.google-analytics.com/batch', { agent, payload: payload, timeout: 15000 }).then(() => {
+      wreck.request('post', 'https://www.google-analytics.com/batch', { agent: this._agent, payload: payload, timeout: 15000 }).then(() => {
         debug('Completed request to google analytics measurement protocol API')
       })
     }

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,4 +1,4 @@
-const wreck = require('@hapi/wreck')
+const fetch = require('node-fetch')
 const BATCH_INTERVAL = process.env.HAPI_GAPI_BATCH_INTERVAL || 15000
 const BATCH_SIZE = process.env.HAPI_GAPI_BATCH_SIZE || 20
 const MAX_QUEUE_TIME = 14400000
@@ -149,7 +149,7 @@ module.exports = class Analytics {
         .join('\n')
       debug('Processing buffered payload: \n%s', payload)
       // Don't await the request - the api always returns a 200 (even on error) and we don't want to block the server request being handled.
-      wreck.request('post', 'https://www.google-analytics.com/batch', { payload: payload, timeout: 15000 }).then(() => {
+      fetch('https://www.google-analytics.com/batch', { method: 'POST', body: payload, timeout: 15000 }).then(() => {
         debug('Completed request to google analytics measurement protocol API')
       })
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra/hapi-gapi",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4279,11 +4279,6 @@
         "path-to-regexp": "^1.7.0"
       }
     },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -235,11 +235,18 @@
       }
     },
     "@hapi/boom": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.2.tgz",
-      "integrity": "sha512-uJEJtiNHzKw80JpngDGBCGAmWjBtzxDCz17A9NO2zCi8LLBlb5Frpq4pXwyN+2JQMod4pKz5BALwyneCgDg89Q==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-8.0.1.tgz",
+      "integrity": "sha512-SnBM2GzEYEA6AGFKXBqNLWXR3uNBui0bkmklYXX1gYtevVhDTy2uakwkSauxvIWMtlANGRhzChYg95If3FWCwA==",
       "requires": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.5.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+          "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
+        }
       }
     },
     "@hapi/bossy": {
@@ -294,8 +301,7 @@
     "@hapi/bourne": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
-      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
-      "dev": true
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
     "@hapi/call": {
       "version": "5.1.3",
@@ -1300,19 +1306,19 @@
       }
     },
     "@hapi/wreck": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
-      "integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-16.0.1.tgz",
+      "integrity": "sha512-fL6IwZ5nk1jBMLBPugt72u23rw8KnnyupLor7TZihgvAXTulxJprUe9YiCLuGbKsEBh2qDo31ixvLCSaxC2+xQ==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "8.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x"
       },
       "dependencies": {
-        "@hapi/bourne": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
-          "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+        "@hapi/hoek": {
+          "version": "8.5.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+          "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -234,6 +234,14 @@
         }
       }
     },
+    "@hapi/boom": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.2.tgz",
+      "integrity": "sha512-uJEJtiNHzKw80JpngDGBCGAmWjBtzxDCz17A9NO2zCi8LLBlb5Frpq4pXwyN+2JQMod4pKz5BALwyneCgDg89Q==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
     "@hapi/bossy": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bossy/-/bossy-5.0.0.tgz",
@@ -1291,6 +1299,23 @@
         }
       }
     },
+    "@hapi/wreck": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
+      "integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
+      },
+      "dependencies": {
+        "@hapi/bourne": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+          "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+        }
+      }
+    },
     "@iarna/toml": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.3.tgz",
@@ -1438,6 +1463,14 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "aggregate-error": {
       "version": "3.0.1",
@@ -2963,6 +2996,15 @@
       "resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.5.tgz",
       "integrity": "sha512-aI5tKwNTBzOZApHIynaAwecLBv8TlZTEy/P4Sj2SzzAhBrGuI8yGZ0UIXVPQzOHGS+to2mjb04iy6VWt/8+d8A==",
       "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
     },
     "human-signals": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra/hapi-gapi",
-  "version": "1.1.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -234,21 +234,6 @@
         }
       }
     },
-    "@hapi/boom": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-8.0.1.tgz",
-      "integrity": "sha512-SnBM2GzEYEA6AGFKXBqNLWXR3uNBui0bkmklYXX1gYtevVhDTy2uakwkSauxvIWMtlANGRhzChYg95If3FWCwA==",
-      "requires": {
-        "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
-          "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
-        }
-      }
-    },
     "@hapi/bossy": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bossy/-/bossy-5.0.0.tgz",
@@ -301,7 +286,8 @@
     "@hapi/bourne": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
-      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "dev": true
     },
     "@hapi/call": {
       "version": "5.1.3",
@@ -1302,23 +1288,6 @@
           "requires": {
             "@hapi/hoek": "^8.3.0"
           }
-        }
-      }
-    },
-    "@hapi/wreck": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-16.0.1.tgz",
-      "integrity": "sha512-fL6IwZ5nk1jBMLBPugt72u23rw8KnnyupLor7TZihgvAXTulxJprUe9YiCLuGbKsEBh2qDo31ixvLCSaxC2+xQ==",
-      "requires": {
-        "@hapi/boom": "8.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
-          "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
         }
       }
     },
@@ -4261,6 +4230,11 @@
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "@hapi/joi": "^17.1.1",
-    "@hapi/wreck": "^17.1.0",
+    "@hapi/wreck": "^16.0.1",
     "debug": "^4.3.1",
     "https-proxy-agent": "^5.0.0",
     "ip-anonymize": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "@hapi/wreck": "^16.0.1",
     "debug": "^4.3.1",
     "https-proxy-agent": "^5.0.0",
-    "ip-anonymize": "^0.1.0",
-    "node-fetch": "^2.6.1"
+    "ip-anonymize": "^0.1.0"
   },
   "devDependencies": {
     "@hapi/code": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "@hapi/joi": "^17.1.1",
+    "@hapi/wreck": "^17.1.0",
     "debug": "^4.3.1",
+    "https-proxy-agent": "^5.0.0",
     "ip-anonymize": "^0.1.0",
     "node-fetch": "^2.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra/hapi-gapi",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "hapi plugin to enable server-side google analytics platform integration",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "@hapi/joi": "^17.1.1",
-    "@hapi/wreck": "^16.0.1",
     "debug": "^4.3.1",
-    "ip-anonymize": "^0.1.0"
+    "ip-anonymize": "^0.1.0",
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@hapi/code": "^8.0.3",

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -217,6 +217,38 @@ describe('Analytics', () => {
     expect(wreckSpy.args[0][2].payload.includes(encodedAdditionalData)).to.be.true()
   })
 
+  it('uses agent if https_proxy environment variable is defined', async () => {
+    sinon.stub(process, 'env').value({ https_proxy: 'some value' })
+
+    sinon.stub(wreck, 'request').callsFake(async (method, url, options) => {
+      expect(options.agent).to.exist()
+    })
+
+    const analytics = new Analytics({
+      propertySettings: TEST_PROPERTY_SETTINGS,
+      sessionIdProducer: TEST_SESSION,
+      attributionProducer: TEST_NO_ATTRIBUTION,
+      batchSize: 1
+    })
+
+    analytics.ga(DEFAULT_REQUEST_OBJ).pageView()
+  })
+
+  it('does not use agent if https_proxy environment variable is not defined', async () => {
+    sinon.stub(wreck, 'request').callsFake(async (method, url, options) => {
+      expect(options.agent).to.not.exist()
+    })
+
+    const analytics = new Analytics({
+      propertySettings: TEST_PROPERTY_SETTINGS,
+      sessionIdProducer: TEST_SESSION,
+      attributionProducer: TEST_NO_ATTRIBUTION,
+      batchSize: 1
+    })
+
+    analytics.ga(DEFAULT_REQUEST_OBJ).pageView()
+  })
+
   it('handles events', () => {
     const analytics = new Analytics({
       propertySettings: TEST_PROPERTY_SETTINGS,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2190

After deploying rcr to dev, it was discovered that the @hapi/wreck module was not sending requests properly behind a proxy. Additional config is required to support this https://github.com/hapijs/wreck/issues/64