### PR TITLE
Update Ubuntu version used for GH Actions builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - housekeeping/update-gha-config
   schedule:
     - cron: '0 8 1 * *'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   tests:
     name: tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       CI: true
     steps:
@@ -42,7 +42,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   npm-publication:
     name: npm-publication
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: tests
     env:
       CI: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - housekeeping/update-gha-config
   schedule:
     - cron: '0 8 1 * *'
 


### PR DESCRIPTION
GitHub Actions dropped support for Ubuntu 18.04 last year.